### PR TITLE
Migrate to JSON3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,11 +8,13 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 HTTP = "1"
 JSON3 = "1"
 StructTypes = "1"
+TimeZones = "1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,18 @@
 name = "GitForge"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
 authors = ["Chris de Graaf <me@cdg.dev>"]
-version = "0.2.9"
+version = "1.0.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-JSON2 = "2535ab7d-5cd8-5a07-80ac-9b1792aadce3"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
 HTTP = "1"
-JSON2 = "0.3.2"
+JSON3 = "1"
+StructTypes = "1"
 julia = "1.6"
 
 [extras]

--- a/src/GitForge.jl
+++ b/src/GitForge.jl
@@ -12,6 +12,8 @@ const AStr = AbstractString
 const HEADERS = ["Content-Type" => "application/json"]
 
 function __init__()
+    # TODO: Apparently using @__DIR__ doesn't play well with PackageCompiler.
+    # Look into alternate methods of getting the package version e.g. Pkg.dependencies.
     proj = read(joinpath(dirname(@__DIR__), "Project.toml"), String)
     pkgver = match(r"version = \"(.+)\"", proj)[1]
     push!(HEADERS, "User-Agent" => "Julia v$VERSION (GitForge v$pkgver)")

--- a/src/GitForge.jl
+++ b/src/GitForge.jl
@@ -5,7 +5,8 @@ using Base.StackTraces: StackTrace
 
 using Dates: Period, UTC, now
 using HTTP: HTTP
-using JSON2: JSON2
+using JSON3: JSON3
+using StructTypes: StructTypes, UnorderedStruct
 
 const AStr = AbstractString
 const HEADERS = ["Content-Type" => "application/json"]

--- a/src/forge.jl
+++ b/src/forge.jl
@@ -6,6 +6,19 @@ The most common example is [GitHub](https://github.com).
 """
 abstract type Forge end
 
+abstract type ForgeType end
+
+StructTypes.StructType(::Type{<:ForgeType}) = UnorderedStruct()
+
+function StructTypes.keywordargs(::Type{T}) where T <: ForgeType
+    M = parentmodule(T)
+    return if isdefined(M, :DEFAULT_DATEFORMAT)
+        (; dateformat=M.DEFAULT_DATEFORMAT)
+    else
+        NamedTuple()
+    end
+end
+
 """
     Endpoint(
         method::Symbol,

--- a/src/forges/GitHub/GitHub.jl
+++ b/src/forges/GitHub/GitHub.jl
@@ -19,7 +19,7 @@ using ..GitForge:
 
 using Dates
 using HTTP
-using JSON2
+using JSON3: JSON3
 
 export GitHubAPI, NoToken, Token, JWT
 

--- a/src/forges/GitHub/GitHub.jl
+++ b/src/forges/GitHub/GitHub.jl
@@ -24,11 +24,7 @@ using JSON3: JSON3
 export GitHubAPI, NoToken, Token, JWT
 
 const DEFAULT_URL = "https://api.github.com"
-const JSON_OPTS = (
-    dateformat=dateformat"y-m-d",
-    read_datetimeformats=[dateformat"y-m-dTH:M:SZ"],
-    write_datetimeformat=dateformat"y-m-dTH:M:SZ",
-)
+const DEFAULT_DATEFORMAT = dateformat"y-m-dTH:M:S\Z"
 
 abstract type AbstractToken end
 

--- a/src/forges/GitLab/GitLab.jl
+++ b/src/forges/GitLab/GitLab.jl
@@ -19,15 +19,13 @@ using ..GitForge:
 using Dates
 using HTTP
 using JSON3: JSON3
+using StructTypes: StructTypes
+using TimeZones: ZonedDateTime
 
 export GitLabAPI, NoToken, OAuth2Token, PersonalAccessToken
 
 const DEFAULT_URL = "https://gitlab.com/api/v4"
-const JSON_OPTS = (
-    dateformat=dateformat"y-m-d",
-    read_datetimeformats=[dateformat"y-m-dTH:M:S.sZ", dateformat"y-m-dTH:M:S.s+ss:ss", dateformat"y-m-dTH:M:S.s-ss:ss"],
-    write_datetimeformat=dateformat"y-m-dTH:M:S.sZ",
-)
+const DEFAULT_DATEFORMAT = dateformat"y-m-dTH:M:S.s\Z"
 
 abstract type AbstractToken end
 

--- a/src/forges/GitLab/GitLab.jl
+++ b/src/forges/GitLab/GitLab.jl
@@ -18,7 +18,7 @@ using ..GitForge:
 
 using Dates
 using HTTP
-using JSON2
+using JSON3: JSON3
 
 export GitLabAPI, NoToken, OAuth2Token, PersonalAccessToken
 
@@ -121,7 +121,7 @@ encode(owner::AStr, subgroup::AStr, repo::AStr) = HTTP.escapeuri("$owner/$subgro
 
 function ismember(r::HTTP.Response)
     r.status == 404 && return false
-    m = JSON2.read(IOBuffer(r.body), Member)
+    m = JSON3.read(IOBuffer(r.body), Member)
     return m.access_level !== nothing && m.access_level >= 30
 end
 

--- a/src/forges/GitLab/commits.jl
+++ b/src/forges/GitLab/commits.jl
@@ -1,3 +1,9 @@
+@json struct CommitStats
+    additions::Int
+    deletions::Int
+    total::Int
+end
+
 @json struct Commit
     id::String
     short_id::String
@@ -8,12 +14,17 @@
     committer_email::String
     created_at::DateTime
     message::String
-    committed_date::DateTime
-    authored_date::DateTime
+    committed_date::ZonedDateTime
+    authored_date::ZonedDateTime
     parent_ids::Vector{String}
     last_pipeline::Pipeline
     status::String
+    web_url::String
+    stats::CommitStats
+    project_id::Int
 end
+
+StructTypes.keywordargs(::Type{Commit}) = (; dateformat="y-m-dTH:M:S.sssz")
 
 endpoint(::GitLabAPI, ::typeof(get_commit), owner::AStr, repo::AStr, ref::AStr) =
     Endpoint(:GET, "/projects/$(encode(owner, repo))/repository/commits/$ref")

--- a/src/forges/GitLab/users.jl
+++ b/src/forges/GitLab/users.jl
@@ -43,7 +43,7 @@ endpoint(::GitLabAPI, ::typeof(get_user), id::Integer) = Endpoint(:GET, "/users/
 endpoint(::GitLabAPI, ::typeof(get_user), name::AStr) =
     Endpoint(:GET, "/users"; query=Dict(:username => name))
 postprocessor(::GitLabAPI, ::typeof(get_user)) = DoSomething() do r
-    v = JSON2.read(IOBuffer(r.body), Union{User, Vector{User}})
+    v = JSON3.read(IOBuffer(r.body), Union{User, Vector{User}})
     return if v isa User
         v
     else

--- a/src/request.jl
+++ b/src/request.jl
@@ -83,7 +83,7 @@ Computes a value to be returned from an HTTP response.
 """
 postprocess(::DoNothing, ::HTTP.Response, ::Type) = nothing
 postprocess(p::JSON, r::HTTP.Response, ::Type{T}) where T =
-    p.f(JSON2.read(IOBuffer(r.body), T))
+    p.f(JSON3.read(IOBuffer(r.body), T))
 postprocess(p::DoSomething, r::HTTP.Response, ::Type) = p.f(r)
 
 # Requests.
@@ -139,9 +139,9 @@ function request(
     query = merge(request_query(f, fun), ep.query, query)
     opts = merge(request_kwargs(f, fun), Dict(pairs(request_opts)))
     body = if ep.method in (:PATCH, :POST, :PUT)
-        JSON2.write(Dict(kwargs))
+        JSON3.write(kwargs)
     else
-        merge!(query, Dict(kwargs))
+        merge!(query, kwargs)
         HTTP.nobody
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,8 @@
 using GitForge
 const GF = GitForge
 
-using HTTP: HTTP
-using JSON2: JSON2
+using HTTP, JSON3, Logging
 using Test: @test, @testset, TestLogger
-using Logging
 
 function capture(f::Function)
     t = TestLogger()
@@ -35,7 +33,7 @@ GF.into(::TestForge, ::typeof(get_user)) = Symbol
     end
 
     @testset "Request options" begin
-        body = JSON2.read(IOBuffer(resp.body))
+        body = JSON3.read(IOBuffer(resp.body))
         @test startswith(get(body, :url, ""), "https://httpbin.org")
         @test get(get(body, :headers, Dict()), :Foo, "") == "Bar"
         @test get(get(body, :args, Dict()), :foo, "") == "bar"
@@ -55,7 +53,7 @@ GF.into(::TestForge, ::typeof(get_user)) = Symbol
 
         @test isempty(out)
 
-        body = JSON2.read(IOBuffer(resp.body))
+        body = JSON3.read(IOBuffer(resp.body))
         @test haskey(body.headers, :Foo)
         @test get(body.headers, :A, "") == "B"
         @test haskey(get(body, :args, Dict()), :foo)


### PR DESCRIPTION
Closes #9, ref #22

I'm pretty sure that the weirdness of dateformats for GitLab is isolated to commits; I went through all the GitLab API docs and I only found the nonstandard format there. So I've not allowed for any user configuration of the formats, but we can change them on a per-type level and a per-field level too.

Due to some limitations in JSON3/StructTypes, I've also gotten rid of the `_extras` field on all types, and any keys that come from the API that are not present in the struct will throw an error. I definitely don't want that, so I'm looking at a couple of options:

- Add a `ignoreextras` flag to JSON3 that makes it not throw errors for extra keys (easy, https://github.com/JuliaData/StructTypes.jl/pull/52)
- Add a `KeywordArgsStruct` to  StructTypes to facilitate implementing `_extras` in the same way we did before (not so easy)