### PR TITLE
Added endpoints to get repositories with single string

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GitForge"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
 authors = ["Chris de Graaf <me@cdg.dev>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/forges/GitHub/repositories.jl
+++ b/src/forges/GitHub/repositories.jl
@@ -122,6 +122,8 @@ endpoint(::GitHubAPI, ::typeof(get_user_repos), id::Integer) =
     Endpoint(:GET, "/users/$id/projects")
 into(::GitHubAPI, ::typeof(get_user_repos)) = Vector{Repo}
 
+endpoint(::GitHubAPI, ::typeof(get_repo), owner_repo::AStr) =
+    Endpoint(:GET, "/repos/$owner_repo")
 endpoint(::GitHubAPI, ::typeof(get_repo), owner::AStr, repo::AStr) =
     Endpoint(:GET, "/repos/$owner/$repo")
 into(::GitHubAPI, ::typeof(get_repo)) = Repo

--- a/src/forges/GitLab/projects.jl
+++ b/src/forges/GitLab/projects.jl
@@ -117,6 +117,8 @@ endpoint(::GitLabAPI, ::typeof(get_user_repos), name::AStr) =
     Endpoint(:GET, "/users/$name/repos")
 into(::GitLabAPI, ::typeof(get_user_repos)) = Vector{Project}
 
+endpoint(::GitLabAPI, ::typeof(get_repo), owner_repo::AStr) =
+    Endpoint(:GET, "/projects/$(encode(owner_repo))")
 endpoint(::GitLabAPI, ::typeof(get_repo), owner::AStr, repo::AStr) =
     Endpoint(:GET, "/projects/$(encode(owner, repo))")
 endpoint(::GitLabAPI, ::typeof(get_repo), owner::AStr, subgroup::AStr, repo::AStr) =


### PR DESCRIPTION
As part of the changes to `CompatHelper.jl` we are storing the names of repos as single strings `Owner/RepoName`. This works fine with the existing underlying [GitHub.jl](https://github.com/JuliaWeb/GitHub.jl/blob/4bcd93d7d856e47d2f582adbe660427207f8a39a/src/repositories/repositories.jl#L49) package, however since we are moving to this one we need this functionality. It could be achieved by:

a) Storing two env vars, one for owner, another for the repo name
b) Using `split()` code
c) Adding this endpoint in

I feel like this is the most clean solution going forward.