### PR TITLE
Add owner/repo get_repo endpoint function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GitForge"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
 authors = ["Chris de Graaf <me@cdg.dev>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/api.jl
+++ b/src/api.jl
@@ -44,12 +44,14 @@ Get the currently authenticated user's repositories, or those of a user by name 
 @endpoint get_user_repos(name_or_id::Union{AStr, Integer})
 
 """
+    get_repo(::Forge, owner_repo::$AStr)
     get_repo(::Forge, owner::$AStr, repo::$AStr)
     get_repo(::Forge, id::Integer)
     get_repo(::Forge, owner::$AStr, subgroup::$AStr, repo::$AStr)
 
 Get a repository by owner and name or ID.
 """
+@endpoint get_repo(owner_repo::AStr)
 @endpoint get_repo(owner::AStr, repo::AStr)
 @endpoint get_repo(id::Integer)
 @endpoint get_repo(owner::AStr, subgroup::AStr, repo::AStr)


### PR DESCRIPTION
Looks like this was missed in https://github.com/JuliaWeb/GitForge.jl/pull/26
Seems like you need to also add the function signature here

@mattBrzezinski 