### PR TITLE
Add list_pipeline_schedules for gitlab

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GitForge"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
 authors = ["Chris de Graaf <me@cdg.dev>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/api.jl
+++ b/src/api.jl
@@ -256,3 +256,12 @@ Delete a given pull request comment.
 @endpoint delete_pull_request_comment(
     project::Integer, pull_request_id::Integer, comment_id::Integer
 )
+
+"""
+    list_pipeline_schedules(::Forge, project::Integer; kwargs...)
+    list_pipeline_schedules(::Forge, owner::$AStr, repo::$AStr; kwargs...)
+
+List all existing pipeline schedules for a project.
+"""
+@endpoint list_pipeline_schedules(project::Integer)
+@endpoint list_pipeline_schedules(ownert::AStr, repo::AStr)

--- a/src/forges/GitLab/GitLab.jl
+++ b/src/forges/GitLab/GitLab.jl
@@ -113,6 +113,7 @@ include("commits.jl")
 include("branches.jl")
 include("tags.jl")
 include("notes.jl")
+include("pipeline_schedules.jl")
 
 encode(owner::AStr, repo::AStr) = HTTP.escapeuri("$owner/$repo")
 encode(org::AStr) = HTTP.escapeuri(org)

--- a/src/forges/GitLab/pipeline_schedules.jl
+++ b/src/forges/GitLab/pipeline_schedules.jl
@@ -1,0 +1,35 @@
+@json struct PipelineSchedule
+    id::Int
+    description::String
+    ref::String
+    cron::String
+    cron_timezone::String
+    next_run_at::DateTime
+    active::Bool
+    created_at::DateTime
+    updated_at::DateTime
+    owner::User
+end
+
+## Pipeline Schedules
+
+# Get All Pipeline Schedules
+# https://docs.gitlab.com/ee/api/pipeline_schedules.html#get-all-pipeline-schedules
+function endpoint(
+    ::GitLabAPI,
+    ::typeof(list_pipeline_schedules),
+    project::Integer,
+)
+    return EndPoint(:GET, "/projects/$project/pipeline_schedules")
+end
+
+function endpoint(
+    ::GitLabAPI,
+    ::typeof(list_pipeline_schedules),
+    owner::AStr,
+    repo::AStr,
+)
+    return EndPoint(:GET, "/projects/$(encode(owner, repo))/pipeline_schedules")
+end
+
+into(::GitLabAPI, ::typeof(list_pipeline_schedules)) = Vector{PipelineSchedule}


### PR DESCRIPTION
Need this endpoint added. Not too sure what the equivalent endpoint for github would be. 