### PR TITLE
move version checking from `__init__` to precompile time

### DIFF
--- a/src/GitForge.jl
+++ b/src/GitForge.jl
@@ -12,10 +12,7 @@ const HEADERS = ["Content-Type" => "application/json"]
 
 const proj = read(joinpath(dirname(@__DIR__), "Project.toml"), String)
 const pkgver = match(r"version = \"(.+)\"", proj)[1]
-
-function __init__()
-    push!(HEADERS, "User-Agent" => "Julia v$VERSION (GitForge v$pkgver)")
-end
+push!(HEADERS, "User-Agent" => "Julia v$VERSION (GitForge v$pkgver)")
 
 include("forge.jl")
 include("ratelimits.jl")

--- a/src/GitForge.jl
+++ b/src/GitForge.jl
@@ -10,9 +10,10 @@ using JSON2: JSON2
 const AStr = AbstractString
 const HEADERS = ["Content-Type" => "application/json"]
 
+const proj = read(joinpath(dirname(@__DIR__), "Project.toml"), String)
+const pkgver = match(r"version = \"(.+)\"", proj)[1]
+
 function __init__()
-    proj = read(joinpath(dirname(@__DIR__), "Project.toml"), String)
-    pkgver = match(r"version = \"(.+)\"", proj)[1]
     push!(HEADERS, "User-Agent" => "Julia v$VERSION (GitForge v$pkgver)")
 end
 

--- a/src/GitForge.jl
+++ b/src/GitForge.jl
@@ -10,10 +10,13 @@ using JSON2: JSON2
 const AStr = AbstractString
 const HEADERS = ["Content-Type" => "application/json"]
 
-const proj = read(joinpath(dirname(@__DIR__), "Project.toml"), String)
-const pkgver = match(r"version = \"(.+)\"", proj)[1]
-push!(HEADERS, "User-Agent" => "Julia v$VERSION (GitForge v$pkgver)")
+let
+    proj = read(joinpath(dirname(@__DIR__), "Project.toml"), String)
+    pkgver = match(r"version = \"(.+)\"", proj)[1]
+    push!(HEADERS, "User-Agent" => "Julia v$VERSION (GitForge v$pkgver)")
+end
 
+Base.include_dependency("../Project.toml")
 include("forge.jl")
 include("ratelimits.jl")
 include("request.jl")


### PR DESCRIPTION
Reading files (like the project file) during runtime has some issues when people
want to use this package with PackageCompiler. This should fix it (and also
reduce the load time slightly for the package).
