### PR TITLE
JSON3 fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GitForge"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
 authors = ["Chris de Graaf <me@cdg.dev>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -9,9 +9,10 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-HTTP = "1"
+HTTP = "0.9, 1"
 JSON3 = "1"
 StructTypes = "1"
 TimeZones = "1"

--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ julia> @assert user.login == "christopher-dG"
 Eventually, the goal is to cover all the "basic" parts of services like GitHub, such as repositories, issues, pull requests, etc.
 However, this library was mostly motivated by development on [Registrator](https://github.com/JuliaRegistries/Registrator.jl), so at the moment most of the wrapped endpoints are just the ones needed for that specific task.
 More recently, it's being used for efforts on [CompatHelper](https://github.com/JuliaRegistries/CompatHelper.jl) and [TagBot](https://github.com/JuliaRegistries/TagBot).
+
+Forges will cover different methods of the API and they use @not_implemented to note unimplemented methods.

--- a/src/GitForge.jl
+++ b/src/GitForge.jl
@@ -3,10 +3,12 @@ module GitForge
 using Base.Iterators: Pairs
 using Base.StackTraces: StackTrace
 
+using Dates
 using Dates: Period, UTC, now
 using HTTP: HTTP
-using JSON3: JSON3
-using StructTypes: StructTypes, UnorderedStruct
+using JSON3: JSON3, @writechar, @check, realloc!
+using StructTypes: StructTypes, UnorderedStruct, StructType, DictType, StringType
+import StructTypes: construct, constructfrom
 
 const AStr = AbstractString
 const HEADERS = ["Content-Type" => "application/json"]
@@ -16,6 +18,11 @@ let
     pkgver = match(r"version = \"(.+)\"", proj)[1]
     push!(HEADERS, "User-Agent" => "Julia v$VERSION (GitForge v$pkgver)")
 end
+
+"""
+The supertype of all other exceptions raised by API functions.
+"""
+abstract type ForgeError <: Exception end
 
 Base.include_dependency("../Project.toml")
 include("forge.jl")

--- a/src/api.jl
+++ b/src/api.jl
@@ -119,8 +119,8 @@ List a repository's pull requests.
 @endpoint get_pull_requests(repo::Integer)
 
 """
-    create_pull_requests(::Forge, owner::$AStr, repo::$AStr; kwargs...)
-    create_pull_requests(::Forge, project::Integer; kwargs...)
+    create_pull_request(::Forge, owner::$AStr, repo::$AStr; kwargs...)
+    create_pull_request(::Forge, project::Integer; kwargs...)
 
 Create a pull request.
 """

--- a/src/forge.jl
+++ b/src/forge.jl
@@ -1,3 +1,19 @@
+struct ForgeAPIError <: GitForge.ForgeError
+    message::String
+end
+
+struct ForgeAPINotImplemented <: GitForge.ForgeError
+    func::Function
+    args::Tuple
+    noted::Bool
+    api
+end
+
+Base.showerror(io::IO, e::ForgeAPINotImplemented) =
+    print(io, typeof(e.api), " has not implemented the function $(e.func) for arguments $(typeof.((e.api, e.func, e.args...)))\n  use: @not_implemented(::$(typeof(e.api)), ::typeof($(e.func)), $(join(map(a-> "::$(typeof(a))", e.args), ", ")))")
+
+not_implemented(api, func, args...; noted = true) = throw(ForgeAPINotImplemented(func, args, noted, api))
+
 """
 A forge is an online platform for Git repositories.
 The most common example is [GitHub](https://github.com).
@@ -8,7 +24,82 @@ abstract type Forge end
 
 abstract type ForgeType end
 
-StructTypes.StructType(::Type{<:ForgeType}) = UnorderedStruct()
+forgeof(::Type) = Nothing
+
+struct FieldContext{Forge, Type, Field}
+    FieldContext{Forge}() where {Forge} = new{Forge, nothing, nothing}()
+    FieldContext{Forge, Type}() where {Forge, Type} = new{Forge, Type, nothing}()
+    FieldContext{Forge, Type, Field}() where {Forge, Type, Field} = new{Forge, Type, Field}()
+end
+
+StructTypes.StructType(::Type{<:ForgeType}) = DictType()
+
+construct(::Type{T}, dict::Dict; kw...) where {T <: ForgeType} =
+    construct(T, Dict(Symbol(k) => v for (k, v) in dict); kw...)
+
+function construct(::Type{T}, dict::Dict{Symbol}; kw...) where {T <: ForgeType}
+    forge = forgeof(T)
+    T(;
+      (k=> try
+           GitForge.constructfield(FieldContext{forge, T, k}(), fieldtype(T, k), get(dict, k, nothing))
+       catch
+           throw(ForgeAPIError("Error constructing field $T.$k from $(repr(get(dict, k, nothing)))\nAll data: $dict"))
+       end
+       for k in fieldnames(T))...,
+      _extras = (; kw..., (k => v for (k, v) in dict if !hasfield(T, k))...),
+      )
+end
+
+showfield(type, name) = "$(parentmodule(type)).$(nameof(type)).$name"
+
+"""
+    constructfield(::::FieldContext{FORGE, OWNER, FIELD}, FT::Type, val)
+
+Override this with your own FORGE, FORGE and OWNER, or FORGE, OWNER,
+and FIELD to handle converting fields and types for your forge.
+
+This allows forges to handle their own date and UUID formats, etc.
+
+Note that untyped JSON objects will convert to named tuples.
+"""
+constructfield(::FieldContext{FORGE, OWNER, FIELD}, FT::Type, val) where {FORGE, OWNER, FIELD} = try
+    constructfrom(FT, val)
+catch err
+    @error "Could not construct $(showfield(OWNER, FIELD))::$FT from value $(repr(val))" exception=(err,catch_backtrace())
+    rethrow(err)
+end
+    
+# all fields should be assingable to nothing because of the @json macro
+constructfield(::FieldContext, ::Type, ::Nothing) = nothing
+
+# convert Vectors recursively
+constructfield(ctx::FieldContext, ::Type{Union{Vector{FT}, Nothing}}, vec::Vector) where FT =
+    [constructfield(ctx, FT, v) for v in vec]
+
+# convert Vectors recursively
+constructfield(ctx::FieldContext, ::Type, vec::Vector) where FT =
+    [constructfield(ctx, Union{Any, Nothing}, v) for v in vec]
+
+# convert dicts recursively
+function constructfield(ctx::FieldContext, ::Type{Union{Dict{K, V}, Nothing}}, dict::Dict) where
+    {K, V}
+    Dict(construct(K, k) => constructfield(ctx, Union{V, Nothing}, v) for (k,v) in dict)
+end
+
+function constructfield(ctx::FieldContext, ::Type{Union{Dict{K, V}, Nothing}}, dict::Dict{K2,V2}) where {K, V, K2 <: Union{AbstractString, Symbol}, V2}
+    Dict(construct(K, k) => constructfield(ctx, Union{V, Nothing}, v) for (k,v) in dict)
+end
+
+# convert symbol/string dicts with unassociated types into named tuples
+function constructfield(ctx::FieldContext, FT::Type{Union{NamedTuple, Nothing}}, dict::Dict{K, V}) where {K <: Union{AbstractString, Symbol}, V}
+    constructfrom(FT, (; (Symbol(k) => constructfield(ctx, Union{Any, Nothing}, v)
+                                         for (k, v) in dict)...))
+end
+
+StructTypes.keyvaluepairs(obj::T) where {T <: ForgeType} = [
+    [k=>getfield(obj, k) for k in fieldnames(T) if k != :_extras]...,
+    pairs(obj._extras)...,
+]
 
 function StructTypes.keywordargs(::Type{T}) where T <: ForgeType
     M = parentmodule(T)
@@ -17,6 +108,50 @@ function StructTypes.keywordargs(::Type{T}) where T <: ForgeType
     else
         NamedTuple()
     end
+end
+
+JSON3.write(::StructTypes.DictType, buf, pos, len, v::T; kw...) where {T <: ForgeType} =
+    JSON3.write(FieldContext{forgeof(T), T}(), buf, pos, len, v; kw...)
+
+"""
+    write(::FieldContext{FORGE, TYPE, FIELD}, buf, pos, len, x; kw...)
+
+Override this for custom JSON3 encodings for a particular forge, forge
+and type, or forge, type, and field.
+
+This allows forges to encode their own dates and UUIDs properly.
+
+Returns the new buf, pos, len
+"""
+write(::FieldContext, buf, pos, len, x; kw...) =
+     JSON3.write(StructType(x), buf, pos, len, x; kw...)
+
+# modified from JSON3.write(::DictType, buf, pos, len, x::T; kw...)
+function JSON3.write(ctx::FieldContext{FORGE, T}, buf, pos, len, x::T; kw...) where {FORGE, T}
+    @writechar '{'
+
+    first = true
+    for (k, v) in StructTypes.keyvaluepairs(x)
+        if first
+            first = false
+        else
+            @writechar ','
+        end
+        k == :_extras && continue
+        buf, pos, len = JSON3.write(StringType(), buf, pos, len, Base.string(k))
+        @writechar ':'
+        buf, pos, len = write(FieldContext{FORGE, T, k}(), buf, pos, len, v; kw...)
+    end
+
+    for (ek, ev) in pairs(x._extras)
+        @writechar ','
+        buf, pos, len = JSON3.write(StringType(), buf, pos, len, Base.string(ek))
+        @writechar ':'
+        buf, pos, len = write(FieldContext{FORGE, T, :_extras}(), buf, pos, len, ev; kw...)
+    end
+
+    @writechar '}'
+    return buf, pos, len
 end
 
 """
@@ -106,8 +241,16 @@ Returns an [`Endpoint`](@ref) for a given function.
 Trailing arguments are usually important for routing.
 For example, [`get_user`](@ref) can take some ID parameter which becomes part of the URL.
 """
-endpoint(f::T, ::Function, args...) where T <: Forge =
-    error("$T has not implemented this function")
+endpoint(forge::T, func::Function, args...) where T <: Forge =
+    throw(ForgeAPINotImplemented(func, args, false, forge))
+
+macro not_implemented(api::Expr, func::Expr, rest...)
+    api_name = length(api.args) == 2 ? api.args[1] : :api
+    func_name = func.args[1].args[end]
+    rest = [rest[n].head !== :(::) ? rest[n] : :($(Symbol("a$n"))::$(rest[n].args[end])) for n in 1:length(rest)]
+    rest_names = map(a-> a.head !== :(::) ? a : a.args[1], rest)
+    :(endpoint(api::$(esc((api.args[end]))), $(esc(func)), $(rest...)) = throw(ForgeAPINotImplemented($func_name, ($(rest_names...),), true, $api_name)))
+end
 
 """
     has_rate_limits(::Forge, ::Function) -> Bool

--- a/src/forges/GitHub/GitHub.jl
+++ b/src/forges/GitHub/GitHub.jl
@@ -2,7 +2,7 @@
 
 module GitHub
 
-import ..GitForge: endpoint, into, postprocessor
+import ..GitForge: endpoint, into, postprocessor, @forge
 
 using ..GitForge
 using ..GitForge:
@@ -15,7 +15,8 @@ using ..GitForge:
     OnRateLimit,
     RateLimiter,
     HEADERS,
-    ORL_THROW
+    ORL_THROW,
+    @not_implemented
 
 using Dates
 using HTTP
@@ -24,7 +25,7 @@ using JSON3: JSON3
 export GitHubAPI, NoToken, Token, JWT
 
 const DEFAULT_URL = "https://api.github.com"
-const DEFAULT_DATEFORMAT = dateformat"y-m-dTH:M:S\Z"
+const DEFAULT_DATEFORMAT = dateformat"yyyy-mm-ddTHH:MM:SS\Z"
 
 abstract type AbstractToken end
 
@@ -92,6 +93,7 @@ struct GitHubAPI <: Forge
         return new(token, url, has_rate_limits, on_rate_limit, RateLimiter(), RateLimiter())
     end
 end
+@forge GitHubAPI
 
 GitForge.base_url(g::GitHubAPI) = g.url
 GitForge.request_headers(g::GitHubAPI, ::Function) = [HEADERS; auth_headers(g.token)]
@@ -115,6 +117,6 @@ include("branches.jl")
 include("tags.jl")
 include("comments.jl")
 
-ismemberorcollaborator(r::HTTP.Response) = r.status != 404
+ismemberorcollaborator(r::HTTP.Response) = !(r.status in [403, 404])
 
 end

--- a/src/forges/GitHub/branches.jl
+++ b/src/forges/GitHub/branches.jl
@@ -34,7 +34,7 @@ function endpoint(
     owner::AStr,
     repo::AStr,
 )
-    return EndPoint(:GET, "repos/$owner/$repo/branches")
+    return Endpoint(:GET, "repos/$owner/$repo/branches")
 end
 into(::GitHubAPI, ::typeof(get_branches)) = Vector{Branch}
 

--- a/src/forges/GitHub/comments.jl
+++ b/src/forges/GitHub/comments.jl
@@ -39,6 +39,7 @@ function endpoint(
 )
     return Endpoint(:GET, "/repos/$owner/$repo/issues/$pull_request_id/comments")
 end
+@not_implemented(::GitHubAPI, ::typeof(list_pull_request_comments), ::Int64, ::Int64)
 into(::GitHubAPI, ::typeof(list_pull_request_comments)) = Vector{Comment}
 
 # Get Single Pull Request (Issue) Comment
@@ -53,6 +54,7 @@ function endpoint(
     return Endpoint(
         :GET, "/repos/$owner/$repo/issues/comments/$comment_id")
 end
+@not_implemented(::GitHubAPI, ::typeof(get_pull_request_comment), ::Int64, ::Int64, ::Int64)
 info(::GitHubAPI, ::typeof(get_pull_request_comment)) = Comment
 
 # Create Pull Request (Issue) Comment
@@ -66,6 +68,7 @@ function endpoint(
 )
     return Endpoint(:POST, "/repos/$owner/$repo/issues/$pull_request_id/comments")
 end
+@not_implemented(::GitHubAPI, ::typeof(create_pull_request_comment), ::Int64, ::Int64)
 into(::GitHubAPI, ::typeof(create_pull_request_comment)) = Comment
 
 # Update Pull Request (Issue) Comment
@@ -79,6 +82,7 @@ function endpoint(
 )
     return Endpoint(:PATCH, "/repos/$owner/$repo/issues/comments/$comment_id")
 end
+@not_implemented(::GitHubAPI, ::typeof(update_pull_request_comment), ::Int64, ::Int64, ::Int64)
 into(::GitHubAPI, ::typeof(update_pull_request_comment)) = Comment
 
 # Delete Pull Request (Issue) Comment
@@ -92,4 +96,8 @@ function endpoint(
 )
     return Endpoint(:DELETE, "/repos/$owner/$repo/issues/comments/$comment_id")
 end
+@not_implemented(
+    ::GitHubAPI, ::typeof(delete_pull_request_comment),
+    project::Integer, pull_request_id::Integer, comment_id::Integer
+)
 into(::GitHubAPI, ::typeof(delete_pull_request_comment)) = Comment

--- a/src/forges/GitHub/commits.jl
+++ b/src/forges/GitHub/commits.jl
@@ -59,4 +59,5 @@ end
 
 endpoint(::GitHubAPI, ::typeof(get_commit), owner::AStr, repo::AStr, ref::AStr) =
     Endpoint(:GET, "/repos/$owner/$repo/commits/$ref")
+@not_implemented(::GitHubAPI, ::typeof(get_commit), ::Int64, ::String)
 into(::GitHubAPI, ::typeof(get_commit)) = Commit

--- a/src/forges/GitHub/organizations.jl
+++ b/src/forges/GitHub/organizations.jl
@@ -1,4 +1,7 @@
 endpoint(::GitHubAPI, ::typeof(is_member), org::AStr, user::AStr) =
     Endpoint(:GET, "/orgs/$org/members/$user"; allow_404=true)
+@not_implemented(::GitHubAPI, ::typeof(is_member), ::String, ::Int64)
 postprocessor(::GitHubAPI, ::typeof(is_member)) = DoSomething(ismemberorcollaborator)
 into(::GitHubAPI, ::typeof(is_member)) = Bool
+
+@not_implemented(::GitHubAPI, ::typeof(groups), )

--- a/src/forges/GitHub/pull_requests.jl
+++ b/src/forges/GitHub/pull_requests.jl
@@ -119,16 +119,27 @@ end
 
 endpoint(::GitHubAPI, ::typeof(get_pull_requests), owner::AStr, repo::AStr) =
     Endpoint(:GET, "/repos/$owner/$repo/pulls")
+@not_implemented(::GitHubAPI, ::typeof(get_pull_requests), ::Int64)
 into(::GitHubAPI, ::typeof(get_pull_requests)) = Vector{PullRequest}
 
 endpoint(::GitHubAPI, ::typeof(get_pull_request), owner::AStr, repo::AStr, number::Integer) =
     Endpoint(:GET, "/repos/$owner/$repo/pulls/$number")
+@not_implemented(::GitHubAPI, ::typeof(get_pull_request), ::Int64, ::Int64)
 into(::GitHubAPI, ::typeof(get_pull_request)) = PullRequest
 
 endpoint(::GitHubAPI, ::typeof(create_pull_request), owner::AStr, repo::AStr) =
     Endpoint(:POST, "/repos/$owner/$repo/pulls")
+@not_implemented(::GitHubAPI, ::typeof(create_pull_request), ::Int64)
 into(::GitHubAPI, ::typeof(create_pull_request)) = PullRequest
 
 endpoint(::GitHubAPI, ::typeof(update_pull_request), owner::AStr, repo::AStr, number::Integer) =
     Endpoint(:PATCH, "/repos/$owner/$repo/pulls/$number")
+@not_implemented(::GitHubAPI, ::typeof(update_pull_request), ::Int64, ::Int64)
 into(::GitHubAPI, ::typeof(update_pull_request)) = PullRequest
+
+@not_implemented(::GitHubAPI, ::typeof(subscribe_to_pull_request), ::Int64, ::Int64)
+
+@not_implemented(::GitHubAPI, ::typeof(unsubscribe_from_pull_request), ::Int64, ::Int64)
+
+@not_implemented(::GitHubAPI, ::typeof(list_pipeline_schedules), ::Int64)
+@not_implemented(::GitHubAPI, ::typeof(list_pipeline_schedules), ::String, ::String)

--- a/src/forges/GitHub/repositories.jl
+++ b/src/forges/GitHub/repositories.jl
@@ -120,25 +120,31 @@ end
 endpoint(::GitHubAPI, ::typeof(get_user_repos)) = Endpoint(:GET, "/user/repos")
 endpoint(::GitHubAPI, ::typeof(get_user_repos), id::Integer) =
     Endpoint(:GET, "/users/$id/projects")
+@not_implemented(::GitHubAPI, ::typeof(get_user_repos), ::String)
 into(::GitHubAPI, ::typeof(get_user_repos)) = Vector{Repo}
 
 endpoint(::GitHubAPI, ::typeof(get_repo), owner_repo::AStr) =
     Endpoint(:GET, "/repos/$owner_repo")
 endpoint(::GitHubAPI, ::typeof(get_repo), owner::AStr, repo::AStr) =
     Endpoint(:GET, "/repos/$owner/$repo")
+@not_implemented(::GitHubAPI, ::typeof(get_repo), ::String, ::String, ::String)
 into(::GitHubAPI, ::typeof(get_repo)) = Repo
 
 endpoint(::GitHubAPI, ::typeof(create_repo)) =
     Endpoint(:POST, "/user/repos")
 endpoint(::GitHubAPI, ::typeof(create_repo), org::AStr) =
     Endpoint(:POST, "/orgs/$org/repos")
+@not_implemented(::GitHubAPI, ::typeof(create_repo), ::Int64)
+@not_implemented(api::GitHubAPI, ::typeof(create_repo), namespace::AStr, repo::AStr)
 into(::GitHubAPI, ::typeof(create_repo)) = Repo
 
 endpoint(::GitHubAPI, ::typeof(is_collaborator), owner::AStr, repo::AStr, user::AStr) =
     Endpoint(:GET, "/repos/$owner/$repo/collaborators/$user"; allow_404=true)
+@not_implemented(::GitHubAPI, ::typeof(is_collaborator), ::String, ::String, ::Int64)
 postprocessor(::GitHubAPI, ::typeof(is_collaborator)) = DoSomething(ismemberorcollaborator)
 into(::GitHubAPI, ::typeof(is_collaborator)) = Bool
 
 endpoint(::GitHubAPI, ::typeof(get_file_contents), owner::AStr, repo::AStr, path::AStr) =
     Endpoint(:GET, "/repos/$owner/$repo/contents/$path")
+@not_implemented(::GitHubAPI, ::typeof(get_file_contents), ::Int64, ::String)
 into(::GitHubAPI, ::typeof(get_file_contents)) = FileContents

--- a/src/forges/GitHub/tags.jl
+++ b/src/forges/GitHub/tags.jl
@@ -13,4 +13,5 @@ end
 
 endpoint(::GitHubAPI, ::typeof(get_tags), owner::AStr, repo::AStr) =
     Endpoint(:GET, "/repos/$owner/$repo/git/refs/tags")
+@not_implemented(::GitHubAPI, ::typeof(get_tags), ::Int64)
 into(::GitHubAPI, ::typeof(get_tags)) = Vector{Tag}

--- a/src/forges/GitHub/users.jl
+++ b/src/forges/GitHub/users.jl
@@ -47,11 +47,18 @@ end
 end
 
 endpoint(::GitHubAPI, ::typeof(get_user)) = Endpoint(:GET, "/user")
+@not_implemented(::GitHubAPI, ::typeof(get_user), ::Int64)
 endpoint(::GitHubAPI, ::typeof(get_user), name::AStr) = Endpoint(:GET, "/users/$name")
 into(::GitHubAPI, ::typeof(get_user)) = User
 
 endpoint(::GitHubAPI, ::typeof(get_users)) = Endpoint(:GET, "/users")
 into(::GitHubAPI, ::typeof(get_users)) = Vector{User}
 
+@not_implemented(api::GitHubAPI, ::typeof(update_user), id::Integer)
+
 endpoint(::GitHubAPI, ::typeof(update_user)) = Endpoint(:PATCH, "/user")
 into(::GitHubAPI, ::typeof(update_user)) = User
+
+@not_implemented(::GitHubAPI, ::typeof(create_user))
+
+@not_implemented(::GitHubAPI, ::typeof(delete_user), id::Integer)

--- a/src/forges/GitLab/groups.jl
+++ b/src/forges/GitLab/groups.jl
@@ -18,9 +18,9 @@ end
 
 endpoint(::GitLabAPI, ::typeof(is_member), org::AStr, id::Integer) =
     Endpoint(:GET, "/groups/$(encode(org))/members/$id"; allow_404=true)
+@not_implemented(api::GitLabAPI, ::typeof(is_member), org::AStr, user::AStr)
 postprocessor(::GitLabAPI, ::typeof(is_member)) = DoSomething(ismember)
 into(::GitLabAPI, ::typeof(is_member)) = Bool
 
-endpoint(::GitLabAPI, ::typeof(groups)) =
-    Endpoint(:GET, "/groups")
+endpoint(::GitLabAPI, ::typeof(groups)) = Endpoint(:GET, "/groups")
 into(::GitLabAPI, ::typeof(groups)) = Vector{Group}

--- a/src/forges/GitLab/notes.jl
+++ b/src/forges/GitLab/notes.jl
@@ -25,6 +25,13 @@ function endpoint(
 )
     return Endpoint(:GET, "/projects/$project/merge_requests/$pull_request_id/notes")
 end
+@not_implemented(
+    api::GitLabAPI,
+    ::typeof(list_pull_request_comments),
+    owner::AStr,
+    repo::AStr,
+    pull_request_id::Integer
+)
 into(::GitLabAPI, ::typeof(list_pull_request_comments)) = Vector{Note}
 
 # Get Single Merge Request Note
@@ -40,6 +47,13 @@ function endpoint(
         :GET, "/projects/$project/merge_requests/$pull_request_id/notes/$comment_id"
     )
 end
+@not_implemented(
+    api::GitLabAPI,
+    ::typeof(get_pull_request_comment),
+    owner::AStr,
+    repo::AStr,
+    comment_id::Integer,
+)
 into(::GitLabAPI, ::typeof(get_pull_request_comment)) = Note
 
 # Create Merge Request Note
@@ -52,6 +66,13 @@ function endpoint(
 )
     return Endpoint(:POST, "/projects/$project/merge_requests/$pull_request_id/notes")
 end
+@not_implemented(
+    api::GitLabAPI,
+    ::typeof(create_pull_request_comment),
+    owner::AStr,
+    repo::AStr,
+    pull_request_id::Integer,
+)
 into(::GitLabAPI, ::typeof(create_pull_request_comment)) = Note
 
 # Update Merge Request Note
@@ -67,6 +88,13 @@ function endpoint(
         :PUT, "/projects/$project/merge_requests/$pull_request_id/notes/$comment_id"
     )
 end
+@not_implemented(
+    api::GitLabAPI,
+    ::typeof(update_pull_request_comment),
+    owner::AStr,
+    repo::AStr,
+    comment_id::Integer,
+)
 into(::GitLabAPI, ::typeof(update_pull_request_comment)) = Note
 
 # Delete Merge Request Note
@@ -82,4 +110,5 @@ function endpoint(
         :DELETE, "/projects/$project/merge_requests/$pull_request_id/notes/$comment_id"
     )
 end
+@not_implemented(::GitLabAPI, ::typeof(delete_pull_request_comment), ::String, ::String, ::Int64)
 into(::GitLabAPI, ::typeof(delete_pull_request_comment)) = Note

--- a/src/forges/GitLab/projects.jl
+++ b/src/forges/GitLab/projects.jl
@@ -120,6 +120,7 @@ end
 
 endpoint(::GitLabAPI, ::typeof(get_user_repos)) =
     Endpoint(:GET, "/projects"; query=Dict("membership" => true))
+@not_implemented(api::GitLabAPI, ::typeof(get_user_repos), id::Integer)
 endpoint(::GitLabAPI, ::typeof(get_user_repos), name::AStr) =
     Endpoint(:GET, "/users/$name/repos")
 into(::GitLabAPI, ::typeof(get_user_repos)) = Vector{Project}
@@ -136,17 +137,20 @@ endpoint(::GitLabAPI, ::typeof(create_repo)) =
     Endpoint(:POST, "/projects")
 endpoint(::GitLabAPI, ::typeof(create_repo), id::Integer) =
     Endpoint(:POST, "/projects/user/$id")
+@not_implemented(api::GitLabAPI, ::typeof(create_repo), repo::AStr)
+@not_implemented(api::GitLabAPI, ::typeof(create_repo), namespace::AStr, repo::AStr)
 into(::GitLabAPI, ::typeof(create_repo)) = Project
 
 endpoint(::GitLabAPI, ::typeof(is_collaborator), owner::AStr, repo::AStr, id::Integer) =
     Endpoint(:GET, "/projects/$(encode(owner, repo))/members/$id"; allow_404=true)
+@not_implemented(api::GitLabAPI, ::typeof(is_collaborator), owner::AStr, repo::AStr, id::AStr)
 postprocessor(::GitLabAPI, ::typeof(is_collaborator)) = DoSomething(ismember)
 into(::GitLabAPI, ::typeof(is_collaborator)) = Bool
 
 endpoint(::GitLabAPI, ::typeof(get_file_contents), id::Integer, path::AStr) =
-    Endpoint(:GET, "/projects/$id/repository/files/$path"; query=Dict(:ref => "master"))
+    Endpoint(:GET, "/projects/$id/repository/files/$(HTTP.escapeuri(path))"; query=Dict(:ref => "master"))
 endpoint(::GitLabAPI, ::typeof(get_file_contents), owner::AStr, repo::AStr, path::AStr) =
-    Endpoint(:GET, "/projects/$(encode(owner, repo))/repository/files/$path"; query=Dict(:ref => "master"))
+    Endpoint(:GET, "/projects/$(encode(owner, repo))/repository/files/$(HTTP.escapeuri(path))"; query=Dict(:ref => "master"))
 into(::GitLabAPI, ::typeof(get_file_contents)) = FileContents
 
 endpoint(::GitLabAPI, ::typeof(list_issues), project::Integer) =

--- a/src/forges/GitLab/users.jl
+++ b/src/forges/GitLab/users.jl
@@ -55,6 +55,7 @@ into(::GitLabAPI, ::typeof(get_user)) = User
 endpoint(::GitLabAPI, ::typeof(get_users)) = Endpoint(:GET, "/users")
 into(::GitLabAPI, ::typeof(get_users)) = Vector{User}
 
+@not_implemented(api::GitLabAPI, ::typeof(update_user))
 endpoint(::GitLabAPI, ::typeof(update_user), id::Integer) = Endpoint(:PUT, "/users/$id")
 postprocessor(::GitLabAPI, ::typeof(update_user)) = DoNothing()
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -12,16 +12,36 @@ end
 
 """
     @json struct T ... end
+    @json FORGETYPE struct T ... end
 
 Create a type that can be parsed from JSON.
+
+Optionally accept a forge type for struct names that do not follow the ModuleAPI convention
 """
 macro json(def::Expr)
+    forge = try
+        getfield(__module__, Symbol(string(nameof(__module__)) * "API"))
+    catch
+        throw("No forge struct named $forge. Make one or pass $(__module__)'s forge struct to @json $(def.args[2])")
+    end
+    json(forge, def)
+end
+
+macro json(forgesym::Symbol, def::Expr)
+    forge = try
+        getfield(__module__, forgesym)
+    catch
+        throw("No struct named $forgesym, pass a valid API to @json $(def.args[2])")
+    end
+    !(forge <: GitForge.ForgeType) && throw("$forge is not a ForgeType, pass a valid API to @json $(def.args[2])")
+    json(forge, def)
+end
+
+function json(forge::Type, def::Expr)
     # TODO: This doesn't work for parametric types or types with supertypes.
     T = esc(def.args[2])
     renames = Tuple{Symbol, Symbol}[]
     names = Symbol[]
-
-    code = Expr[]
 
     for field in def.args[3].args
         field isa Expr || continue
@@ -30,13 +50,13 @@ macro json(def::Expr)
             # Make the field nullable.
             field.args[2] = :(Union{$(esc(field.args[2])), Nothing})
         elseif field.head === :call && field.args[1] === :(=>)
-            push!(names, field.args[2])
             # Convert from => to::F to to::F, and record the old name.
             from = field.args[2]
             to, F = field.args[3].args
             field.head = :(::)
             field.args = [to, :(Union{$(esc(F)), Nothing})]
             push!(renames, (to, from))
+            push!(names, to)
         else
             @warn "Invalid field expression $field"
         end
@@ -45,17 +65,70 @@ macro json(def::Expr)
     # Make the type a subtype of `ForgeType`.
     def.args[2] = :($T <: ForgeType)
 
-    # TODO: Add a field for unhandled keys.
+    # Add a field for unhandled keys.
+    push!(def.args[3].args, :(_extras::NamedTuple))
 
-    # Document the struct.
-    push!(code, :(Base.@__doc__ $def))
-
-    # Create a keyword constructor.
+    # keywords for the keyword constructor.
     kws = map(name -> Expr(:kw, name, :nothing), names)
-    push!(code, :($T(; $(kws...)) = $T($(names...))))
+    extras = esc(:_extras)
 
-    # Set up field renames.
-    push!(code, :(StructTypes.names(::Type{$T}) = $(tuple(renames...))))
+    #pretty equality args
+    a = esc(:a)
+    b = esc(:b)
+    eq = esc(:(Base.:(==)))
 
-    return Expr(:block, code...)
+    quote
+        Base.@__doc__ $def
+    
+        # sort extras so they can compare for equality
+        $T(; $(kws...), $extras) =
+            $T($(names...), (; sort!([pairs($extras)...], by = first)...))
+
+        # equality
+        function $eq($a::$T, $b::$T)
+            $(foldr((x, y)-> :($x && $y), [:($a.$n == $b.$n) for n in [names..., :_extras]]))
+        end
+
+        # Set up field renames.
+        StructTypes.names(::Type{$T}) = $(tuple(renames...))
+
+        # define forgeof(TYPE) = ModuleAPI (or the given forge struct)
+        GitForge.forgeof(::Type{$T}) = $forge
+    end
 end
+
+"""
+    @forge API-STRUCT-NAME
+
+if you have defined DEFAULT_DATEFORMAT, put this after the API struct definition
+to handle date parsing.
+
+Other automatic parsing methods can be added here.
+"""
+macro forge(f)
+    forge = esc(f)
+    result = quote end
+    code = result.args
+    fmt = try
+        getfield(__module__, :DEFAULT_DATEFORMAT)
+    catch
+    end
+    fmt === nothing && return :()
+    quote
+        function GitForge.constructfield(::GitForge.FieldContext{$forge}, ::Type{Union{Date, Nothing}}, str::AbstractString)
+            Date(str, $fmt)
+        end
+        function GitForge.constructfield(::GitForge.FieldContext{$forge}, ::Type{Union{DateTime, Nothing}}, str::AbstractString)
+            DateTime(str, $fmt)
+        end
+        function GitForge.write(::FieldContext{$forge, T, F}, buf, pos, len, date::Date; kw...) where {T, F}
+            JSON3.write(StringType(), buf, pos, len, Dates.format(date, $fmt))
+        end
+        function GitForge.write(::FieldContext{$forge, T, F}, buf, pos, len, date::DateTime; kw...) where {T, F}
+            JSON3.write(StringType(), buf, pos, len, Dates.format(date, $fmt))
+        end
+    end
+end
+
+mungetime(v) =
+    replace(replace(v, r"(\.[0-9]{3})([0-9]*)[+-]" => s"\1+"), r"(:[0-9]{2})([+-])" => s"\1.000\2")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,16 @@
 using GitForge
-const GF = GitForge
-
+using GitForge: AStr, Endpoint, ForgeAPINotImplemented, ForgeAPIError
+using GitForge: GitHub, GitLab
+using GitForge.GitHub: Token, GitHubAPI
+using GitForge.GitLab: GitLabAPI, OAuth2Token
 using HTTP, JSON3, Logging
-using Test: @test, @testset, TestLogger
+using Test: @test, @testset, TestLogger, @test_throws
+
+const GH_TOKEN = Token("secret token")
+const GL_TOKEN = OAuth2Token("secret token")
+const USER = "a user"
+const WORKSPACE = "a workspace"
+const GF = GitForge
 
 function capture(f::Function)
     t = TestLogger()
@@ -58,5 +66,118 @@ GF.into(::TestForge, ::typeof(get_user)) = Symbol
         @test get(body.headers, :A, "") == "B"
         @test haskey(get(body, :args, Dict()), :foo)
         @test get(get(body, :args, Dict()), :a, "") == "b"
+    end
+end
+
+# test whether apis are conformant
+
+function test_api_func(api, (func, args...), auth)
+    exclude(api, func, args...) && return
+    try
+        endpoint = GF.endpoint(api, func, args...)
+        headers = Dict(GF.request_headers(api, func))
+        @test headers["Content-Type"] isa AStr
+        @test match(r"^Julia v.* \(GitForge v.*\)", headers["User-Agent"]) !== nothing
+        if auth
+            @test headers["Authorization"] isa AStr
+        end
+        @test GF.has_rate_limits(api, func) isa Bool
+        @test !GF.has_rate_limits(api, func) || GF.on_rate_limit(api, func) isa GF.OnRateLimit
+        @test endpoint isa Endpoint
+        if hasmethod(GF.into, typeof.((api, func)))
+            @test GF.into(api, func) isa Type
+        else
+            @test typeof(GF.postprocessor(api, func)) in [GF.DoNothing, GF.DoSomething, JSON]
+        end
+        true
+    catch err
+        !(err isa ForgeAPINotImplemented) && rethrow(err)
+        err isa ForgeAPINotImplemented && !err.noted && println(sprint(io-> showerror(io, err)))
+        err isa ForgeAPINotImplemented && !err.noted && @test false
+        false
+    end
+end
+
+mock_id(api) = mock_id(user_id_type(api))
+mock_id(::Type{Integer}) = 1
+mock_id(::Type{String}) = "fred"
+user_id_type(::GitHubAPI) = Integer
+user_id_type(::GitLabAPI) = Integer
+# Bitbucket uses UUID
+
+function test_api(api; auth = false)
+    unimplemented = 0
+    @test GF.base_url(api) isa AStr
+    for func in [
+        get_user, (get_user, "fred"), (get_user, mock_id(api)),
+        get_users,
+        update_user, (update_user, mock_id(api)),
+        create_user, (delete_user, mock_id(api)),
+        get_user_repos, (get_user_repos, "fred"), (get_user_repos, mock_id(api)),
+        (get_repo, "owner/repo"), (get_repo, "owner", "repo"), (get_repo, "owner", "subgroup", "repo"),
+        create_repo, (create_repo, "org"), (create_repo, mock_id(api)), (create_repo, "namespace", "repo"),
+        (get_branch, "owner", "repo", "branch"),
+        (get_branches, "owner", "repo"),
+        (delete_branch, "owner", "repo", "branch"),
+        (get_file_contents, "owner", "repo", "path"), (get_file_contents, mock_id(api), "path"),
+        (get_pull_request, "owner", "repo", mock_id(api)), (get_pull_request, mock_id(api), mock_id(api)),
+        (get_pull_requests, "owner", "repo"), (get_pull_requests, mock_id(api)),
+        (create_pull_request, "owner", "repo"), (create_pull_request, mock_id(api)),
+        (update_pull_request, "owner", "repo", 1), (update_pull_request, mock_id(api), 1),
+        (subscribe_to_pull_request, mock_id(api), mock_id(api)),
+        (unsubscribe_from_pull_request, mock_id(api), mock_id(api)),
+        (get_commit, "owner", "repo", "ref"), (get_commit, mock_id(api), "ref"),
+        (is_collaborator, "owner", "repo", "user"), (is_collaborator, "owner", "repo", mock_id(api)),
+        (is_member, "org", "user"), (is_member, "org", mock_id(api)),
+        groups,
+        (get_tags, "owner", "repo"), (get_tags, mock_id(api)),
+        (list_pull_request_comments, "owner", "repo", mock_id(api)), (list_pull_request_comments, mock_id(api), mock_id(api)),
+        (get_pull_request_comment, "owner", "repo", mock_id(api)), (get_pull_request_comment, mock_id(api), mock_id(api), mock_id(api)),
+        (create_pull_request_comment, "owner", "repo", mock_id(api)), (create_pull_request_comment, mock_id(api), mock_id(api)),
+        (update_pull_request_comment, "owner", "repo", mock_id(api)), (update_pull_request_comment, mock_id(api), mock_id(api), mock_id(api)),
+        (delete_pull_request_comment, "owner", "repo", mock_id(api)), (delete_pull_request_comment, mock_id(api), mock_id(api), mock_id(api)),
+        (list_pipeline_schedules, mock_id(api)), (list_pipeline_schedules, "owner", "repo"),
+        ]
+        tuple = func isa Function ? (func,) : func
+        impl = test_api_func(api, tuple, auth)
+        !impl && (unimplemented += 1)
+    end
+    unimplemented > 0 && println("    $unimplemented unimplmented method$(unimplemented == 1 ? "" : "s")")
+end
+
+"""
+    exclude(api, func, args...)
+
+exclude an api function from testing
+"""
+exclude(_api, _func, _args...) = false
+
+@testset "GitHub.jl" begin
+    api = GitHubAPI(; token = GH_TOKEN)
+    @test api.token == GH_TOKEN
+    @test api.url == GitHub.DEFAULT_URL
+    test_api(api, auth = true)
+end
+
+@testset "GitLab.jl" begin
+    api = GitLabAPI(; token = GL_TOKEN)
+    @test api.token == GL_TOKEN
+    @test api.url == GitLab.DEFAULT_URL
+    test_api(api, auth = true)
+end
+
+# encoding tests
+const ENCODING_SAMPLES = [
+    GitHub.Repo => "{\"has_projects\":true,\"open_issues_count\":0,\"has_pages\":false,\"squash_merge_commit_title\":\"COMMIT_OR_PR_TITLE\",\"keys_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/keys{/key_id}\",\"hooks_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/hooks\",\"license\":null,\"forks\":0,\"homepage\":null,\"assignees_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/assignees{/user}\",\"contributors_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/contributors\",\"clone_url\":\"https://github.com/zot/examplebranchsubdir.jl.git\",\"has_wiki\":true,\"merge_commit_title\":\"MERGE_MESSAGE\",\"private\":false,\"name\":\"examplebranchsubdir.jl\",\"commits_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/commits{/sha}\",\"blobs_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/git/blobs{/sha}\",\"git_commits_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/git/commits{/sha}\",\"notifications_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/notifications{?since,all,participating}\",\"contents_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/contents/{+path}\",\"allow_update_branch\":false,\"issues_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/issues{/number}\",\"watchers_count\":0,\"updated_at\":\"2022-07-21T14:20:23Z\",\"stargazers_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/stargazers\",\"labels_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/labels{/name}\",\"created_at\":\"2022-03-09T06:32:33Z\",\"watchers\":0,\"teams_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/teams\",\"is_template\":false,\"visibility\":\"public\",\"html_url\":\"https://github.com/zot/examplebranchsubdir.jl\",\"url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl\",\"default_branch\":\"master\",\"subscription_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/subscription\",\"fork\":false,\"git_refs_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/git/refs{/sha}\",\"full_name\":\"zot/examplebranchsubdir.jl\",\"merges_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/merges\",\"id\":467805961,\"forks_count\":0,\"milestones_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/milestones{/number}\",\"allow_merge_commit\":true,\"allow_rebase_merge\":true,\"pulls_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/pulls{/number}\",\"svn_url\":\"https://github.com/zot/examplebranchsubdir.jl\",\"subscribers_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/subscribers\",\"git_url\":\"git://github.com/zot/examplebranchsubdir.jl.git\",\"network_count\":0,\"delete_branch_on_merge\":false,\"issue_events_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/issues/events{/number}\",\"branches_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/branches{/branch}\",\"allow_squash_merge\":true,\"tags_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/tags\",\"topics\":[],\"releases_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/releases{/id}\",\"archived\":false,\"permissions\":{\"admin\":true,\"maintain\":true,\"pull\":true,\"push\":true,\"triage\":true},\"pushed_at\":\"2022-03-09T06:32:42Z\",\"statuses_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/statuses/{sha}\",\"comments_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/comments{/number}\",\"use_squash_pr_title_as_default\":false,\"allow_auto_merge\":false,\"language\":\"Julia\",\"owner\":{\"organizations_url\":\"https://api.github.com/users/zot/orgs\",\"starred_url\":\"https://api.github.com/users/zot/starred{/owner}{/repo}\",\"avatar_url\":\"https://avatars.githubusercontent.com/u/26665?v=4\",\"following_url\":\"https://api.github.com/users/zot/following{/other_user}\",\"repos_url\":\"https://api.github.com/users/zot/repos\",\"gravatar_id\":\"\",\"login\":\"zot\",\"gists_url\":\"https://api.github.com/users/zot/gists{/gist_id}\",\"url\":\"https://api.github.com/users/zot\",\"site_admin\":false,\"subscriptions_url\":\"https://api.github.com/users/zot/subscriptions\",\"received_events_url\":\"https://api.github.com/users/zot/received_events\",\"id\":26665,\"html_url\":\"https://github.com/zot\",\"node_id\":\"MDQ6VXNlcjI2NjY1\",\"type\":\"User\",\"events_url\":\"https://api.github.com/users/zot/events{/privacy}\",\"followers_url\":\"https://api.github.com/users/zot/followers\"},\"downloads_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/downloads\",\"allow_forking\":true,\"description\":null,\"collaborators_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/collaborators{/collaborator}\",\"has_issues\":true,\"size\":1,\"disabled\":false,\"mirror_url\":null,\"node_id\":\"R_kgDOG-InCQ\",\"open_issues\":0,\"has_downloads\":true,\"merge_commit_message\":\"PR_TITLE\",\"squash_merge_commit_message\":\"COMMIT_MESSAGES\",\"events_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/events\",\"ssh_url\":\"git@github.com:zot/examplebranchsubdir.jl.git\",\"issue_comment_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/issues/comments{/number}\",\"compare_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/compare/{base}...{head}\",\"git_tags_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/git/tags{/sha}\",\"temp_clone_token\":\"\",\"forks_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/forks\",\"subscribers_count\":1,\"archive_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/{archive_format}{/ref}\",\"languages_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/languages\",\"web_commit_signoff_required\":false,\"stargazers_count\":0,\"deployments_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/deployments\",\"trees_url\":\"https://api.github.com/repos/zot/examplebranchsubdir.jl/git/trees{/sha}\"}",
+    GitLab.User => "{\"is_followed\":false,\"theme_id\":1,\"location\":null,\"confirmed_at\":\"2018-08-25T12:57:20.160Z\",\"created_at\":\"2018-08-25T12:57:20.440Z\",\"state\":\"active\",\"followers\":0,\"private_profile\":false,\"can_create_project\":true,\"website_url\":\"\",\"can_create_group\":true,\"commit_email\":\"bill.burdick@gmail.com\",\"identities\":[{\"provider\":\"github\",\"saml_provider_id\":null,\"extern_uid\":\"26665\"}],\"projects_limit\":100000,\"shared_runners_minutes_limit\":null,\"linkedin\":\"\",\"bot\":false,\"job_title\":\"\",\"following\":0,\"pronouns\":null,\"color_scheme_id\":1,\"external\":false,\"work_information\":null,\"extra_shared_runners_minutes_limit\":null,\"web_url\":\"https://gitlab.com/zot1\",\"name\":\"Bill Burdick\",\"bio\":\"\",\"last_activity_on\":\"2022-09-23\",\"email\":\"bill.burdick@gmail.com\",\"organization\":null,\"username\":\"zot1\",\"two_factor_enabled\":false,\"avatar_url\":\"https://secure.gravatar.com/avatar/5ad6635635270fd81ab229ece9b2d2a0?s=80&d=identicon\",\"local_time\":\"6:55 AM\",\"id\":2742710,\"skype\":\"\",\"public_email\":\"\",\"current_sign_in_at\":\"2022-09-22T07:18:43.706Z\",\"last_sign_in_at\":\"2022-08-02T17:40:49.238Z\",\"twitter\":\"\"}",
+    GitLab.Project => "{\"id\":34333070,\"description\":\"\",\"name\":\"ExampleBranchSubdir.jl\",\"name_with_namespace\":\"Bill Burdick / ExampleBranchSubdir.jl\",\"path\":\"ExampleBranchSubdir.jl\",\"path_with_namespace\":\"zot1/ExampleBranchSubdir.jl\",\"created_at\":\"2022-03-09T07:30:26.467Z\",\"default_branch\":\"master\",\"tag_list\":[],\"topics\":[],\"ssh_url_to_repo\":\"git@gitlab.com:zot1/ExampleBranchSubdir.jl.git\",\"http_url_to_repo\":\"https://gitlab.com/zot1/ExampleBranchSubdir.jl.git\",\"web_url\":\"https://gitlab.com/zot1/ExampleBranchSubdir.jl\",\"readme_url\":null,\"avatar_url\":null,\"forks_count\":1,\"star_count\":0,\"last_activity_at\":\"2022-03-29T21:40:37.298Z\",\"namespace\":{\"id\":3495260,\"name\":\"Bill Burdick\",\"path\":\"zot1\",\"kind\":\"user\",\"full_path\":\"zot1\",\"parent_id\":null,\"avatar_url\":\"https://secure.gravatar.com/avatar/5ad6635635270fd81ab229ece9b2d2a0?s=80\\u0026d=identicon\",\"web_url\":\"https://gitlab.com/zot1\"},\"container_registry_image_prefix\":\"registry.gitlab.com/zot1/examplebranchsubdir.jl\",\"_links\":{\"self\":\"https://gitlab.com/api/v4/projects/34333070\",\"issues\":\"https://gitlab.com/api/v4/projects/34333070/issues\",\"merge_requests\":\"https://gitlab.com/api/v4/projects/34333070/merge_requests\",\"repo_branches\":\"https://gitlab.com/api/v4/projects/34333070/repository/branches\",\"labels\":\"https://gitlab.com/api/v4/projects/34333070/labels\",\"events\":\"https://gitlab.com/api/v4/projects/34333070/events\",\"members\":\"https://gitlab.com/api/v4/projects/34333070/members\",\"cluster_agents\":\"https://gitlab.com/api/v4/projects/34333070/cluster_agents\"},\"packages_enabled\":true,\"empty_repo\":false,\"archived\":false,\"visibility\":\"public\",\"owner\":{\"id\":2742710,\"username\":\"zot1\",\"name\":\"Bill Burdick\",\"state\":\"active\",\"avatar_url\":\"https://secure.gravatar.com/avatar/5ad6635635270fd81ab229ece9b2d2a0?s=80\\u0026d=identicon\",\"web_url\":\"https://gitlab.com/zot1\"},\"resolve_outdated_diff_discussions\":false,\"container_expiration_policy\":{\"cadence\":\"1d\",\"enabled\":false,\"keep_n\":10,\"older_than\":\"90d\",\"name_regex\":\".*\",\"name_regex_keep\":null,\"next_run_at\":\"2022-03-10T07:30:26.514Z\"},\"issues_enabled\":true,\"merge_requests_enabled\":true,\"wiki_enabled\":true,\"jobs_enabled\":true,\"snippets_enabled\":true,\"container_registry_enabled\":true,\"service_desk_enabled\":true,\"service_desk_address\":\"contact-project+zot1-examplebranchsubdir-jl-34333070-issue-@incoming.gitlab.com\",\"can_create_merge_request_in\":true,\"issues_access_level\":\"enabled\",\"repository_access_level\":\"enabled\",\"merge_requests_access_level\":\"enabled\",\"forking_access_level\":\"enabled\",\"wiki_access_level\":\"enabled\",\"builds_access_level\":\"enabled\",\"snippets_access_level\":\"enabled\",\"pages_access_level\":\"enabled\",\"operations_access_level\":\"enabled\",\"analytics_access_level\":\"enabled\",\"container_registry_access_level\":\"enabled\",\"security_and_compliance_access_level\":\"private\",\"emails_disabled\":null,\"shared_runners_enabled\":true,\"lfs_enabled\":true,\"creator_id\":2742710,\"import_url\":\"https://bitbucket.org/zot-julia/examplebranchsubdir.jl.git\",\"import_type\":\"bitbucket\",\"import_status\":\"finished\",\"import_error\":null,\"open_issues_count\":0,\"runners_token\":\"GR1348941BXpcpX3ysWGvAD3ZnN1e\",\"ci_default_git_depth\":20,\"ci_forward_deployment_enabled\":true,\"ci_job_token_scope_enabled\":false,\"ci_separated_caches\":true,\"ci_opt_in_jwt\":false,\"ci_allow_fork_pipelines_to_run_in_parent_project\":true,\"public_jobs\":true,\"build_git_strategy\":\"fetch\",\"build_timeout\":3600,\"auto_cancel_pending_pipelines\":\"enabled\",\"ci_config_path\":\"\",\"shared_with_groups\":[],\"only_allow_merge_if_pipeline_succeeds\":false,\"allow_merge_on_skipped_pipeline\":null,\"restrict_user_defined_variables\":false,\"request_access_enabled\":true,\"only_allow_merge_if_all_discussions_are_resolved\":false,\"remove_source_branch_after_merge\":true,\"printing_merge_request_link_enabled\":true,\"merge_method\":\"merge\",\"squash_option\":\"default_off\",\"enforce_auth_checks_on_uploads\":true,\"suggestion_commit_message\":null,\"merge_commit_template\":null,\"squash_commit_template\":null,\"auto_devops_enabled\":false,\"auto_devops_deploy_strategy\":\"continuous\",\"autoclose_referenced_issues\":true,\"keep_latest_artifact\":true,\"runner_token_expiration_interval\":null,\"external_authorization_classification_label\":\"\",\"requirements_enabled\":false,\"requirements_access_level\":\"enabled\",\"security_and_compliance_enabled\":true,\"compliance_frameworks\":[],\"permissions\":{\"project_access\":{\"access_level\":50,\"notification_level\":3},\"group_access\":null}}",
+]
+
+@testset "encoding" begin
+    for (type, json) in ENCODING_SAMPLES
+        ob1 = JSON3.read(json, type)
+        @test typeof(ob1) == type
+        ob2 = JSON3.read(JSON3.write(ob1), type)
+        @test ob1 == ob2
     end
 end


### PR DESCRIPTION
fixes #40 

add @not_implemented, fix JSON3 support, typeos, use rethrow

`@not_implemented` calls indicate intentional omissions of API methods, which are verified in test cases.

This also adds a facility for forges to customize JSON ecoding and decoding since they handle dates and UUIDs differently (Bitbucket encodes UUIDs like "{82ffb363-eeaf-4dd6-a8d6-d43c95d794f8}").

Note that most of the changes in GitHub/* and GitLab/* are additions of `@not_implemented` calls.
