### PR TITLE
Remove unused parameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GitForge"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
 authors = ["Chris de Graaf <me@cdg.dev>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/forge.jl
+++ b/src/forge.jl
@@ -77,7 +77,7 @@ constructfield(ctx::FieldContext, ::Type{Union{Vector{FT}, Nothing}}, vec::Vecto
     [constructfield(ctx, FT, v) for v in vec]
 
 # convert Vectors recursively
-constructfield(ctx::FieldContext, ::Type, vec::Vector) where FT =
+constructfield(ctx::FieldContext, ::Type, vec::Vector) =
     [constructfield(ctx, Union{Any, Nothing}, v) for v in vec]
 
 # convert dicts recursively


### PR DESCRIPTION
This is causing a warning when precompiling the package:
```
WARNING: method definition for constructfield at .julia/packages/GitForge/lvpEo/src/forge.jl:80 declares type variable FT but does not use it.
```